### PR TITLE
resistor-color: Add initial version of exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -23,6 +23,19 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": ["integers"]
+    },
+    {
+      "slug": "resistor-color",
+      "uuid": "f49a0baa-a309-4814-a123-f41a2d770bdd",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "arrays",
+        "pointers",
+        "enums",
+        "slices"
+      ]
     }
   ]
 }

--- a/exercises/resistor-color/README.md
+++ b/exercises/resistor-color/README.md
@@ -1,0 +1,73 @@
+# Resistor Color
+
+If you want to build something using a Raspberry Pi, you'll probably use _resistors_.
+For this exercise, you need to know two things about them:
+
+* Each resistor has a resistance value.
+* Resistors are small - so small in fact that if you printed the resistance value on them, it would be hard to read.
+
+To get around this problem, manufacturers print color-coded bands onto the resistors to denote their resistance values.
+Each band has a position and a numeric value.
+
+The first 2 bands of a resistor have a simple encoding scheme: each color maps to a single number.
+
+In this exercise you are going to create a helpful program so that you don't have to remember the values of the bands.
+
+These colors are encoded as follows:
+
+- Black: 0
+- Brown: 1
+- Red: 2
+- Orange: 3
+- Yellow: 4
+- Green: 5
+- Blue: 6
+- Violet: 7
+- Grey: 8
+- White: 9
+
+The goal of this exercise is to create a way:
+- to look up the numerical value associated with a particular color band
+- to list the different band colors
+
+Mnemonics map the colors to the numbers, that, when stored as an array, happen to map to their index in the array: Better Be Right Or Your Great Big Values Go Wrong.
+
+More information on the color encoding of resistors can be found in the [Electronic color code Wikipedia article](https://en.wikipedia.org/wiki/Electronic_color_code)
+
+## Getting Started
+
+Make sure you have read the "Guides" section of the
+[Zig track][zig-track] on the Exercism site. This covers
+the basic information on setting up the development environment expected
+by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development][3-tdd-rules].
+
+The included test file can be used to create and run the tests using the `zig test`
+task.
+
+    zig test test.zig
+
+Create just the functions you need to satisfy any compiler errors and get the
+test to fail. Then write just enough code to get the test to pass. Once you've
+done that, move onto the next test.
+
+As you progress through the tests, take the time to refactor your
+implementation for readability and expressiveness and then go on to the next
+test.
+
+Try to use standard Zig facilities in preference to writing your own
+low-level algorithms or facilities by hand.
+
+## Source
+
+Maud de Vries, Erik Schierboom [https://github.com/exercism/problem-specifications/issues/1458](https://github.com/exercism/problem-specifications/issues/1458)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+
+[zig-track]: https://exercism.io/my/tracks/zig
+[3-tdd-rules]: http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd

--- a/exercises/resistor-color/example.zig
+++ b/exercises/resistor-color/example.zig
@@ -1,0 +1,25 @@
+pub const ColorBand = enum(u4) {
+    black,
+    brown,
+    red,
+    orange,
+    yellow,
+    green,
+    blue,
+    violet,
+    grey,
+    white,
+};
+
+const band_colors = [_]ColorBand{
+    .black, .brown, .red, .orange, .yellow,
+    .green, .blue, .violet, .grey, .white,
+};
+
+pub fn color_code(color: ColorBand) isize {
+    return @enumToInt(color);
+}
+
+pub fn colors() []const ColorBand {
+    return &band_colors;
+}

--- a/exercises/resistor-color/resistor_color.zig
+++ b/exercises/resistor-color/resistor_color.zig
@@ -1,0 +1,7 @@
+pub fn color_code(color: ColorBand) isize {
+    @panic("determine the value of a colorband on a resistor");
+}
+
+pub fn colors() []const ColorBand {
+    @panic("refer to a collection of all resistor colorbands");
+}

--- a/exercises/resistor-color/test.zig
+++ b/exercises/resistor-color/test.zig
@@ -1,0 +1,32 @@
+const std = @import("std");
+const testing = std.testing;
+
+const resistor_color = @import("./resistor_color.zig");
+const ColorBand = resistor_color.ColorBand;
+
+test "test black" {
+    const expected = 0;
+    const actual = comptime resistor_color.color_code(.black);
+    comptime testing.expectEqual(expected, actual);
+}
+
+test "test white" {
+    const expected = 9;
+    const actual = comptime resistor_color.color_code(.white);
+    comptime testing.expectEqual(expected, actual);
+}
+
+test "test orange" {
+    const expected = 3;
+    const actual = comptime resistor_color.color_code(.orange);
+    comptime testing.expectEqual(expected, actual);
+}
+
+test "test colors" {
+    const expected = &[_]ColorBand{
+        .black, .brown, .red, .orange, .yellow,
+        .green, .blue, .violet, .grey, .white,
+    };
+    const actual = comptime resistor_color.colors();
+    comptime testing.expectEqualSlices(ColorBand, expected, actual);
+}


### PR DESCRIPTION
The resistor-color exercise works as intended when the example.zig file is imported within the test file.
Currently the test file points to the resistor_color.zig file so that people can download and fill out the file to complete the exercise.
Otherwise, the test file itself sports compile time testing. We should aim to have those types of test be the norm.
Finally, the README.md file has a mock layout and content for when the Zig track is fully "live", so to speak.